### PR TITLE
Add unicode escape for epsilon

### DIFF
--- a/import.py
+++ b/import.py
@@ -316,6 +316,7 @@ def unicode_to_latex(s):
     s = s.replace(u"\x94", u"''")
     s = s.replace(u"\u03a3", u"$\Sigma$")
     s = s.replace(u"z\u030c", u"{\v{z}}")
+    s = s.replace(u"\u2208", u"$\epsilon$")
     return s
 
 


### PR DESCRIPTION
This seems necessary for PoPETs runs to complete (see  https://github.com/cryptobib/db/pull/75)