### PR TITLE
Fix EPRINT import

### DIFF
--- a/import.py
+++ b/import.py
@@ -534,8 +534,8 @@ pattern_multiple_spaces = re.compile(r' +')
 
 def split_authors(s):
     """ return a list of others from an author string from EPRINT - from eprint-update.py """
-    names = pattern_split_authors.split(s)
-    names = [n.strip() for n in names]
+    names = map(lambda x: x.strip(), pattern_split_authors.split(s))
+    names = [n for n in names if n != u'']
     return names
 
 


### PR DESCRIPTION
There's an EPRINT report that has misaligned authors, causing
``import.py`` to try to handle an author with name ``''``.

This change makes sure that no empty strings are passed on.